### PR TITLE
Fix CICD by adding a dependency in package.json

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.5",
-    "@git-skyline/common": "*",
-    "@git-skyline/github-graphql": "*",
+    "@git-skyline/common": "workspace:*",
+    "@git-skyline/github-graphql": "workspace:*",
     "@react-three/drei": "^9.86.3",
     "@react-three/fiber": "^8.14.5",
     "axios": "^1.5.1",
@@ -22,7 +22,7 @@
     "react": "^18",
     "react-dom": "^18",
     "three": "^0.157.0",
-    "ui": "*",
+    "ui": "workspace:*",
     "zod": "^3.22.4",
     "zustand": "^4.4.3"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.5",
-    "@git-skyline/common": "workspace:*",
-    "@git-skyline/github-graphql": "workspace:*",
+    "@git-skyline/common": "*",
+    "@git-skyline/github-graphql": "*",
     "@react-three/drei": "^9.86.3",
     "@react-three/fiber": "^8.14.5",
     "axios": "^1.5.1",
@@ -22,7 +22,7 @@
     "react": "^18",
     "react-dom": "^18",
     "three": "^0.157.0",
-    "ui": "workspace:*",
+    "ui": "*",
     "zod": "^3.22.4",
     "zustand": "^4.4.3"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,7 +14,8 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "@git-skyline/github-graphql": "workspace:*"
   },
   "scripts": {
     "build": "tsup"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "zod": "^3.22.4",
-    "@git-skyline/github-graphql": "workspace:*"
+    "@git-skyline/github-graphql": "*"
   },
   "scripts": {
     "build": "tsup"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "zod": "^3.22.4",
-    "@git-skyline/github-graphql": "*"
+    "@git-skyline/github-graphql": "workspace:*"
   },
   "scripts": {
     "build": "tsup"


### PR DESCRIPTION
When I develop locally with bun, there is no need to specify within-monorepo dependencies. Bun handles everything for me. But this doesn't work on vercel. 

I add @git-skyline/github-graphql as the dep of @git-skyline/common. 